### PR TITLE
fix: persist WineRepository instance across renders with useRef

### DIFF
--- a/NaturalWineDetector/src/hooks/useWineRepository.ts
+++ b/NaturalWineDetector/src/hooks/useWineRepository.ts
@@ -1,7 +1,7 @@
 /**
  * Wine repository hook for managing wine data operations
  */
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { WineRecord } from '../types/WineTypes';
 import { WineRepository } from '../repositories/WineRepository';
 import { handleError } from '../utils/errorHandler';
@@ -12,7 +12,7 @@ export const useWineRepository = () => {
   const [error, setError] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
 
-  const repository = new WineRepository();
+  const repository = useRef(new WineRepository()).current;
 
   const saveWine = async (wine: WineRecord): Promise<void> => {
     try {


### PR DESCRIPTION
## Summary

Fixes `useWineRepository` creating a new `WineRepository()` on every render, causing unnecessary object allocations and stale closure references.

## Changes

- Wrapped `new WineRepository()` in `useRef()` so a single stable instance is reused across the component lifecycle
- Added `useRef` to the React imports

## Verification

- Zero TypeScript errors

Closes #2