### PR TITLE
fix: wrap WineRepository in useRef in AppContext

### DIFF
--- a/NaturalWineDetector/src/context/AppContext.tsx
+++ b/NaturalWineDetector/src/context/AppContext.tsx
@@ -1,7 +1,7 @@
 /**
  * Global application context with state management
  */
-import React, { createContext, useContext, useReducer, ReactNode, useEffect } from 'react';
+import React, { createContext, useContext, useReducer, useRef, ReactNode, useEffect } from 'react';
 import { AppState, AppAction } from '../types/AppTypes';
 import { WineRecord } from '../types/WineTypes';
 import { initializeDatabase } from '../repositories/DatabaseInitializer';
@@ -69,7 +69,7 @@ interface AppProviderProps {
 
 export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
   const [state, dispatch] = useReducer(appReducer, initialState);
-  const wineRepository = new WineRepository();
+  const wineRepository = useRef(new WineRepository()).current;
 
   // Action creators
   const actions = {


### PR DESCRIPTION
Prevents creating a new WineRepository instance on every render by using useRef to persist the instance across re-renders.

Closes #3