### PR TITLE
fix: update deprecated OpenAI model to gpt-4o

### DIFF
--- a/NaturalWineDetector/src/utils/constants.ts
+++ b/NaturalWineDetector/src/utils/constants.ts
@@ -7,7 +7,7 @@ export const DATABASE_VERSION = 1;
 export const API_CONFIG = {
   OPENAI_BASE_URL: 'https://api.openai.com/v1',
   CHAT_COMPLETIONS_ENDPOINT: '/chat/completions',
-  MODEL: 'gpt-4-vision-preview',
+  MODEL: 'gpt-4o',
   MAX_TOKENS: 500,
   TEMPERATURE: 0.1,
   TIMEOUT: 30000, // 30 seconds


### PR DESCRIPTION
The gpt-4-vision-preview model is deprecated. Replace with gpt-4o which supports vision capabilities and is the current recommended model.

Closes #4