### PR TITLE
fix: add data URI prefix to base64 image in ChatGPT API call

### DIFF
--- a/NaturalWineDetector/src/services/ChatGPTService.ts
+++ b/NaturalWineDetector/src/services/ChatGPTService.ts
@@ -259,7 +259,7 @@ export class ChatGPTService {
             {
               type: 'image_url',
               image_url: {
-                url: base64Image,
+                url: `data:image/jpeg;base64,${base64Image}`,
                 detail: 'high'
               }
             }


### PR DESCRIPTION
The OpenAI Vision API requires base64 images to include the data:image/jpeg;base64, prefix. Without it, the API cannot properly decode the image data.

Closes #5