### PR TITLE
fix: add missing analyzeWine dependency to useEffect

### DIFF
--- a/NaturalWineDetector/src/components/WineAnalysisComponent.tsx
+++ b/NaturalWineDetector/src/components/WineAnalysisComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import {
   View,
   Text,
@@ -27,13 +27,7 @@ export const WineAnalysisComponent: React.FC<WineAnalysisProps> = ({
   const [result, setResult] = useState<WineAnalysisResult | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (imageUri) {
-      analyzeWine();
-    }
-  }, [imageUri]);
-
-  const analyzeWine = async () => {
+  const analyzeWine = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
@@ -48,7 +42,13 @@ export const WineAnalysisComponent: React.FC<WineAnalysisProps> = ({
     } finally {
       setLoading(false);
     }
-  };
+  }, [imageUri, onAnalysisComplete, onError]);
+
+  useEffect(() => {
+    if (imageUri) {
+      analyzeWine();
+    }
+  }, [imageUri, analyzeWine]);
 
   const handleRetry = () => {
     analyzeWine();


### PR DESCRIPTION
Wrap analyzeWine in useCallback and add it to the useEffect dependency array to satisfy React's exhaustive-deps rule and prevent stale closures.

Closes #10