### PR TITLE
fix: correct inverted rate limit logic in getRateLimitStatus

### DIFF
--- a/NaturalWineDetector/src/services/ChatGPTService.ts
+++ b/NaturalWineDetector/src/services/ChatGPTService.ts
@@ -440,7 +440,7 @@ export class ChatGPTService {
     canMakeRequest: boolean;
   } {
     const now = Date.now();
-    const canMakeRequest = this.requestCount < 10 && (now - this.rateLimitResetTime < 60000);
+    const canMakeRequest = this.requestCount < 10 || (now - this.rateLimitResetTime >= 60000);
     
     return {
       requestCount: this.requestCount,


### PR DESCRIPTION
The condition used && which required both under-limit AND within the time window, incorrectly returning false when the rate limit window had expired. Changed to || so requests are allowed when either under the count limit OR the time window has reset.

Closes #11