### PR TITLE
fix: make OfflineQueueService constructor private

### DIFF
--- a/NaturalWineDetector/src/services/OfflineQueueService.ts
+++ b/NaturalWineDetector/src/services/OfflineQueueService.ts
@@ -36,7 +36,7 @@ export class OfflineQueueService {
     return OfflineQueueService.instance;
   }
 
-  constructor() {
+  private constructor() {
     this.networkService = NetworkService.getInstance();
     this.initialize();
   }


### PR DESCRIPTION
The singleton pattern requires a private constructor to prevent direct instantiation. Without it, consumers can bypass getInstance() and create multiple instances, defeating the singleton guarantee.

Closes #14