### PR TITLE
fix: change confidence_score column type from INTEGER to REAL

### DIFF
--- a/NaturalWineDetector/src/repositories/DatabaseService.ts
+++ b/NaturalWineDetector/src/repositories/DatabaseService.ts
@@ -130,7 +130,7 @@ export class DatabaseService {
             id TEXT PRIMARY KEY,
             image_uri TEXT NOT NULL,
             is_natural_wine INTEGER NOT NULL,
-            confidence_score INTEGER NOT NULL,
+            confidence_score REAL NOT NULL,
             explanation TEXT NOT NULL,
             consumed INTEGER NOT NULL DEFAULT 0,
             latitude REAL,


### PR DESCRIPTION
The confidence score is a float value (0-100) but was declared as INTEGER in the SQLite schema, causing decimal precision to be lost.

Closes #23