### PR TITLE
fix: set OfflineIndicator showWhenOnline to false

### DIFF
--- a/NaturalWineDetector/App.tsx
+++ b/NaturalWineDetector/App.tsx
@@ -23,7 +23,7 @@ export default function App() {
               <AppInitializer>
                 <AccessibilityAudit />
                 <AppNavigator />
-                <OfflineIndicator showWhenOnline={true} position="top" />
+                <OfflineIndicator showWhenOnline={false} position="top" />
                 <StatusBar style="light" />
               </AppInitializer>
             </WorkflowManager>


### PR DESCRIPTION
The offline indicator should only display when the device is offline. Having showWhenOnline={true} causes it to always be visible, which is confusing and takes up screen space unnecessarily.

Closes #25