### PR TITLE
refactor: extract useNetworkState hook from NetworkService

### DIFF
--- a/NaturalWineDetector/src/components/OfflineIndicator.tsx
+++ b/NaturalWineDetector/src/components/OfflineIndicator.tsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import { View, Text, StyleSheet, Animated } from 'react-native';
-import { useNetworkState } from '../services/NetworkService';
+import { useNetworkState } from '../hooks/useNetworkState';
 
 interface OfflineIndicatorProps {
   showWhenOnline?: boolean;

--- a/NaturalWineDetector/src/components/WineHistoryComponent.tsx
+++ b/NaturalWineDetector/src/components/WineHistoryComponent.tsx
@@ -14,7 +14,7 @@ import {
   RefreshControl,
 } from 'react-native';
 import { WineRecord } from '../types/WineTypes';
-import { useNetworkState } from '../services/NetworkService';
+import { useNetworkState } from '../hooks/useNetworkState';
 
 interface WineHistoryProps {
   wines: WineRecord[];

--- a/NaturalWineDetector/src/hooks/index.ts
+++ b/NaturalWineDetector/src/hooks/index.ts
@@ -1,6 +1,7 @@
 // Export all custom hooks from this file
 export * from './useLocation';
 export * from './useCamera';
+export * from './useNetworkState';
 export * from './useWineRepository';
 export * from './usePermissions';
 export * from './usePerformanceMonitor';

--- a/NaturalWineDetector/src/hooks/useNetworkState.ts
+++ b/NaturalWineDetector/src/hooks/useNetworkState.ts
@@ -1,0 +1,25 @@
+/**
+ * Hook for using network state in React components
+ */
+import { useState, useEffect } from 'react';
+import { NetworkState } from '../types/ErrorTypes';
+import { NetworkService } from '../services/NetworkService';
+
+export const useNetworkState = () => {
+  const [networkState, setNetworkState] = useState<NetworkState>(
+    NetworkService.getInstance().getCurrentState()
+  );
+
+  useEffect(() => {
+    const networkService = NetworkService.getInstance();
+    const unsubscribe = networkService.addListener(setNetworkState);
+
+    return unsubscribe;
+  }, []);
+
+  return {
+    networkState,
+    isOnline: networkState.isConnected && networkState.isInternetReachable,
+    isOffline: !networkState.isConnected || !networkState.isInternetReachable
+  };
+};

--- a/NaturalWineDetector/src/services/NetworkService.ts
+++ b/NaturalWineDetector/src/services/NetworkService.ts
@@ -2,9 +2,7 @@
  * Network connectivity service for offline detection and management
  */
 
-import React from 'react';
 import { NetworkState } from '../types/ErrorTypes';
-import { ErrorHandler } from '../utils/errorHandler';
 
 // Try to import NetInfo, fall back to mock if not available
 let NetInfo: any;
@@ -77,9 +75,6 @@ export class NetworkService {
     const isNowOnline = networkState.isConnected && networkState.isInternetReachable;
 
     this.currentState = networkState;
-
-    // Update error handler with new network state
-    ErrorHandler.updateNetworkState(networkState);
 
     // Notify listeners
     this.listeners.forEach(listener => listener(networkState));
@@ -187,25 +182,3 @@ export class NetworkService {
     });
   }
 }
-
-/**
- * Hook for using network state in React components
- */
-export const useNetworkState = () => {
-  const [networkState, setNetworkState] = React.useState<NetworkState>(
-    NetworkService.getInstance().getCurrentState()
-  );
-
-  React.useEffect(() => {
-    const networkService = NetworkService.getInstance();
-    const unsubscribe = networkService.addListener(setNetworkState);
-
-    return unsubscribe;
-  }, []);
-
-  return {
-    networkState,
-    isOnline: networkState.isConnected && networkState.isInternetReachable,
-    isOffline: !networkState.isConnected || !networkState.isInternetReachable
-  };
-};


### PR DESCRIPTION
Move the React hook into its own file under src/hooks/useNetworkState.ts. Remove React import from the service file. Remove broken ErrorHandler.updateNetworkState call. Update all imports.

Closes #7