### PR TITLE
refactor: replace try/catch require() with ES imports

### DIFF
--- a/NaturalWineDetector/src/services/NetworkService.ts
+++ b/NaturalWineDetector/src/services/NetworkService.ts
@@ -2,22 +2,8 @@
  * Network connectivity service for offline detection and management
  */
 
+import NetInfo from '@react-native-community/netinfo';
 import { NetworkState } from '../types/ErrorTypes';
-
-// Try to import NetInfo, fall back to mock if not available
-let NetInfo: any;
-let NetInfoState: any;
-
-try {
-  const netInfoModule = require('@react-native-community/netinfo');
-  NetInfo = netInfoModule.default || netInfoModule;
-  NetInfoState = netInfoModule.NetInfoState;
-} catch (error) {
-  // Use mock for development
-  const { mockNetInfo } = require('../utils/mockDependencies');
-  NetInfo = mockNetInfo;
-  console.warn('NetInfo not available, using mock implementation');
-}
 
 export class NetworkService {
   private static instance: NetworkService;

--- a/NaturalWineDetector/src/services/OfflineQueueService.ts
+++ b/NaturalWineDetector/src/services/OfflineQueueService.ts
@@ -2,21 +2,10 @@
  * Offline queue service for managing API requests when offline
  */
 
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { OfflineQueueItem, NetworkState } from '../types/ErrorTypes';
 import { NetworkService } from './NetworkService';
 import { ErrorHandler } from '../utils/errorHandler';
-
-// Try to import AsyncStorage, fall back to mock if not available
-let AsyncStorage: any;
-
-try {
-  AsyncStorage = require('@react-native-async-storage/async-storage').default;
-} catch (error) {
-  // Use mock for development
-  const { mockAsyncStorage } = require('../utils/mockDependencies');
-  AsyncStorage = mockAsyncStorage;
-  console.warn('AsyncStorage not available, using mock implementation');
-}
 
 const QUEUE_STORAGE_KEY = '@natural_wine_detector_offline_queue';
 


### PR DESCRIPTION
Replace runtime try/catch require() for @react-native-community/netinfo and @react-native-async-storage/async-storage with proper ES imports. Both are declared dependencies and should be resolved at build time.

Closes #8