### PR TITLE
enhancement: add Jest test infrastructure with initial tests

### DIFF
--- a/NaturalWineDetector/__tests__/repositories/DatabaseUtils.test.ts
+++ b/NaturalWineDetector/__tests__/repositories/DatabaseUtils.test.ts
@@ -1,0 +1,158 @@
+import { wineRecordToRow, rowToWineRecord, validateWineRecord } from '../../src/repositories/DatabaseUtils';
+import { WineRecord, WineRecordRow } from '../../src/types/WineTypes';
+
+const createValidWineRecord = (overrides?: Partial<WineRecord>): WineRecord => ({
+  id: 'wine_test_123',
+  imageUri: 'file:///test/image.jpg',
+  analysisResult: {
+    isNaturalWine: true,
+    confidenceScore: 85,
+    explanation: 'This appears to be a natural wine based on the label.',
+    timestamp: new Date('2025-01-01T00:00:00Z'),
+  },
+  consumed: false,
+  location: {
+    latitude: 59.9139,
+    longitude: 10.7522,
+    accuracy: 10,
+  },
+  notes: 'Great wine!',
+  createdAt: new Date('2025-01-01T12:00:00Z'),
+  ...overrides,
+});
+
+const createValidRow = (): WineRecordRow => ({
+  id: 'wine_test_123',
+  image_uri: 'file:///test/image.jpg',
+  is_natural_wine: 1,
+  confidence_score: 85,
+  explanation: 'This appears to be a natural wine based on the label.',
+  consumed: 0,
+  latitude: 59.9139,
+  longitude: 10.7522,
+  location_accuracy: 10,
+  notes: 'Great wine!',
+  created_at: '2025-01-01T12:00:00.000Z',
+  analysis_timestamp: '2025-01-01T00:00:00.000Z',
+});
+
+describe('wineRecordToRow', () => {
+  it('converts a WineRecord to a database row', () => {
+    const record = createValidWineRecord();
+    const row = wineRecordToRow(record);
+
+    expect(row.id).toBe('wine_test_123');
+    expect(row.image_uri).toBe('file:///test/image.jpg');
+    expect(row.is_natural_wine).toBe(1);
+    expect(row.confidence_score).toBe(85);
+    expect(row.consumed).toBe(0);
+    expect(row.latitude).toBe(59.9139);
+    expect(row.longitude).toBe(10.7522);
+    expect(row.notes).toBe('Great wine!');
+  });
+
+  it('converts consumed: true to 1', () => {
+    const record = createValidWineRecord({ consumed: true });
+    const row = wineRecordToRow(record);
+    expect(row.consumed).toBe(1);
+  });
+
+  it('converts isNaturalWine: false to 0', () => {
+    const record = createValidWineRecord({
+      analysisResult: {
+        ...createValidWineRecord().analysisResult,
+        isNaturalWine: false,
+      },
+    });
+    const row = wineRecordToRow(record);
+    expect(row.is_natural_wine).toBe(0);
+  });
+
+  it('handles missing location', () => {
+    const record = createValidWineRecord({ location: undefined });
+    const row = wineRecordToRow(record);
+    expect(row.latitude).toBeUndefined();
+    expect(row.longitude).toBeUndefined();
+    expect(row.location_accuracy).toBeUndefined();
+  });
+});
+
+describe('rowToWineRecord', () => {
+  it('converts a database row to a WineRecord', () => {
+    const row = createValidRow();
+    const record = rowToWineRecord(row);
+
+    expect(record.id).toBe('wine_test_123');
+    expect(record.imageUri).toBe('file:///test/image.jpg');
+    expect(record.analysisResult.isNaturalWine).toBe(true);
+    expect(record.analysisResult.confidenceScore).toBe(85);
+    expect(record.consumed).toBe(false);
+    expect(record.location?.latitude).toBe(59.9139);
+    expect(record.createdAt).toEqual(new Date('2025-01-01T12:00:00.000Z'));
+  });
+
+  it('converts is_natural_wine: 0 to false', () => {
+    const row = { ...createValidRow(), is_natural_wine: 0 };
+    const record = rowToWineRecord(row);
+    expect(record.analysisResult.isNaturalWine).toBe(false);
+  });
+
+  it('handles missing location fields', () => {
+    const row = { ...createValidRow(), latitude: undefined, longitude: undefined, location_accuracy: undefined };
+    const record = rowToWineRecord(row);
+    expect(record.location).toBeUndefined();
+  });
+});
+
+describe('validateWineRecord', () => {
+  it('validates a correct wine record', () => {
+    const record = createValidWineRecord();
+    const result = validateWineRecord(record);
+    expect(result.isValid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('rejects empty id', () => {
+    const record = createValidWineRecord({ id: '' });
+    const result = validateWineRecord(record);
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toContain('Wine ID is required');
+  });
+
+  it('rejects empty imageUri', () => {
+    const record = createValidWineRecord({ imageUri: '' });
+    const result = validateWineRecord(record);
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toContain('Image URI is required');
+  });
+
+  it('rejects confidence score out of range', () => {
+    const record = createValidWineRecord({
+      analysisResult: {
+        ...createValidWineRecord().analysisResult,
+        confidenceScore: 150,
+      },
+    });
+    const result = validateWineRecord(record);
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toContain('Confidence score must be a number between 0 and 100');
+  });
+
+  it('rejects invalid latitude', () => {
+    const record = createValidWineRecord({
+      location: { latitude: 200, longitude: 10, accuracy: 5 },
+    });
+    const result = validateWineRecord(record);
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toContain('Latitude must be a number between -90 and 90');
+  });
+
+  it('rejects invalid longitude', () => {
+    const record = createValidWineRecord({
+      location: { latitude: 59, longitude: 300, accuracy: 5 },
+    });
+    const result = validateWineRecord(record);
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toContain('Longitude must be a number between -180 and 180');
+  });
+});

--- a/NaturalWineDetector/__tests__/utils/errorHandler.test.ts
+++ b/NaturalWineDetector/__tests__/utils/errorHandler.test.ts
@@ -1,0 +1,167 @@
+import { handleError, ErrorHandler } from '../../src/utils/errorHandler';
+import { ApiError, NetworkError, PermissionError, StorageError, ImageError, LocationError } from '../../src/types/ErrorTypes';
+
+describe('handleError', () => {
+  it('returns message from Error instances', () => {
+    expect(handleError(new Error('test error'))).toBe('test error');
+  });
+
+  it('returns string errors as-is', () => {
+    expect(handleError('string error')).toBe('string error');
+  });
+
+  it('returns fallback for unknown types', () => {
+    expect(handleError(42)).toBe('An unexpected error occurred');
+    expect(handleError(null)).toBe('An unexpected error occurred');
+    expect(handleError(undefined)).toBe('An unexpected error occurred');
+  });
+});
+
+describe('ErrorHandler', () => {
+  describe('createApiError', () => {
+    it('creates an ApiError with type "api"', () => {
+      const error = ErrorHandler.createApiError({
+        message: 'API failed',
+        recoverable: true,
+        timestamp: new Date(),
+        apiEndpoint: '/test',
+      });
+      expect(error.type).toBe('api');
+      expect(error.message).toBe('API failed');
+      expect(error.apiEndpoint).toBe('/test');
+    });
+  });
+
+  describe('createNetworkError', () => {
+    it('creates a NetworkError with type "network"', () => {
+      const error = ErrorHandler.createNetworkError({
+        message: 'No network',
+        recoverable: true,
+        timestamp: new Date(),
+        isOffline: true,
+      });
+      expect(error.type).toBe('network');
+      expect(error.isOffline).toBe(true);
+    });
+  });
+
+  describe('createStorageError', () => {
+    it('creates a StorageError with type "storage"', () => {
+      const error = ErrorHandler.createStorageError({
+        message: 'Storage full',
+        recoverable: false,
+        timestamp: new Date(),
+        operation: 'write',
+      });
+      expect(error.type).toBe('storage');
+      expect(error.operation).toBe('write');
+    });
+  });
+
+  describe('handle', () => {
+    it('handles rate-limited API errors', () => {
+      const error: ApiError = {
+        type: 'api',
+        message: 'Rate limited',
+        recoverable: true,
+        timestamp: new Date(),
+        apiEndpoint: '/chat',
+        rateLimited: true,
+      };
+      const result = ErrorHandler.handle(error);
+      expect(result.shouldRetry).toBe(true);
+      expect(result.retryDelay).toBe(60000);
+    });
+
+    it('handles 401 API errors', () => {
+      const error: ApiError = {
+        type: 'api',
+        message: 'Unauthorized',
+        recoverable: false,
+        timestamp: new Date(),
+        apiEndpoint: '/chat',
+        statusCode: 401,
+      };
+      const result = ErrorHandler.handle(error);
+      expect(result.shouldRetry).toBe(false);
+      expect(result.shouldShowSettings).toBe(true);
+    });
+
+    it('handles network timeout errors', () => {
+      const error: NetworkError = {
+        type: 'network',
+        message: 'Timeout',
+        recoverable: true,
+        timestamp: new Date(),
+        isTimeout: true,
+      };
+      const result = ErrorHandler.handle(error);
+      expect(result.shouldRetry).toBe(true);
+      expect(result.userMessage).toContain('timed out');
+    });
+
+    it('handles permission errors', () => {
+      const error: PermissionError = {
+        type: 'permission',
+        message: 'Camera denied',
+        recoverable: false,
+        timestamp: new Date(),
+        permission: 'camera',
+        canOpenSettings: true,
+      };
+      const result = ErrorHandler.handle(error);
+      expect(result.shouldRetry).toBe(false);
+      expect(result.userMessage).toContain('Camera');
+    });
+
+    it('handles storage full errors', () => {
+      const error: StorageError = {
+        type: 'storage',
+        message: 'Full',
+        recoverable: false,
+        timestamp: new Date(),
+        operation: 'write',
+        isStorageFull: true,
+      };
+      const result = ErrorHandler.handle(error);
+      expect(result.shouldRetry).toBe(false);
+      expect(result.userMessage).toContain('storage is full');
+    });
+
+    it('handles image format errors', () => {
+      const error: ImageError = {
+        type: 'image',
+        message: 'Bad format',
+        recoverable: false,
+        timestamp: new Date(),
+        reason: 'invalid_format',
+      };
+      const result = ErrorHandler.handle(error);
+      expect(result.shouldRetry).toBe(false);
+      expect(result.userMessage).toContain('Invalid image format');
+    });
+
+    it('handles location permission denied', () => {
+      const error: LocationError = {
+        type: 'location',
+        message: 'Denied',
+        recoverable: false,
+        timestamp: new Date(),
+        reason: 'permission_denied',
+      };
+      const result = ErrorHandler.handle(error);
+      expect(result.shouldRetry).toBe(false);
+      expect(result.shouldShowSettings).toBe(true);
+    });
+  });
+
+  describe('getErrorStats', () => {
+    it('returns error statistics', () => {
+      const stats = ErrorHandler.getErrorStats();
+      expect(stats).toHaveProperty('total');
+      expect(stats).toHaveProperty('byType');
+      expect(stats).toHaveProperty('recent');
+      expect(typeof stats.total).toBe('number');
+    });
+  });
+});

--- a/NaturalWineDetector/jest.config.js
+++ b/NaturalWineDetector/jest.config.js
@@ -1,0 +1,16 @@
+module.exports = {
+  preset: 'jest-expo',
+  transformIgnorePatterns: [
+    'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|native-base|react-native-svg)',
+  ],
+  setupFilesAfterSetup: ['<rootDir>/jest.setup.js'],
+  collectCoverageFrom: [
+    'src/**/*.{ts,tsx}',
+    '!src/**/*.d.ts',
+    '!src/**/index.ts',
+    '!src/types/**',
+  ],
+  coverageDirectory: 'coverage',
+  testPathIgnorePatterns: ['/node_modules/', '/dist/'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+};

--- a/NaturalWineDetector/jest.setup.js
+++ b/NaturalWineDetector/jest.setup.js
@@ -1,0 +1,8 @@
+// Global test setup
+// Add any global mocks or setup here
+
+// Mock __DEV__ global
+global.__DEV__ = true;
+
+// Silence console warnings in tests
+jest.spyOn(console, 'warn').mockImplementation(() => {});

--- a/NaturalWineDetector/package.json
+++ b/NaturalWineDetector/package.json
@@ -11,7 +11,9 @@
     "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
     "type-check": "tsc --noEmit",
     "check-node": "node scripts/check-node-version.js",
-    "test-eas": "node scripts/test-eas-setup.js"
+    "test-eas": "node scripts/test-eas-setup.js",
+    "test": "jest",
+    "test:coverage": "jest --coverage"
   },
   "dependencies": {
 
@@ -40,12 +42,15 @@
   },
   "devDependencies": {
     "@react-native-community/eslint-config": "^3.2.0",
+    "@types/jest": "^29.5.12",
     "@types/react": "~18.3.0",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
     "eslint": "^8.57.0",
     "eslint-plugin-react": "^7.35.0",
     "eslint-plugin-react-native": "^4.1.0",
+    "jest": "^29.7.0",
+    "jest-expo": "~52.0.0",
     "typescript": "~5.3.3"
   },
   "engines": {


### PR DESCRIPTION
- Add jest.config.js with jest-expo preset
- Add jest.setup.js for global test configuration  
- Add jest-expo and @types/jest devDependencies
- Add test and test:coverage npm scripts
- Add initial tests for ErrorHandler and DatabaseUtils

Closes #12