### PR TITLE
Fix CI: add jest environment to ESLint config

### DIFF
--- a/NaturalWineDetector/.eslintrc.json
+++ b/NaturalWineDetector/.eslintrc.json
@@ -30,6 +30,14 @@
     "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }],
     "no-console": ["warn", { "allow": ["warn", "error"] }]
   },
+  "overrides": [
+    {
+      "files": ["__tests__/**/*", "jest.setup.js"],
+      "env": {
+        "jest": true
+      }
+    }
+  ],
   "ignorePatterns": [
     "node_modules/",
     "dist/",


### PR DESCRIPTION
jest.setup.js was failing ESLint with 'jest is not defined' (no-undef) because the jest environment was not configured. Adds an override for test files and jest.setup.js.