### PR TITLE
Fix CI: ignore jest.setup.js in ESLint

### DIFF
--- a/NaturalWineDetector/.eslintignore
+++ b/NaturalWineDetector/.eslintignore
@@ -5,3 +5,4 @@ build/
 coverage/
 scripts/
 *.config.js
+*.setup.js


### PR DESCRIPTION
jest.setup.js uses the jest global which triggers no-undef. Since it's a config file, ignoring it in ESLint is the cleanest fix.