### PR TITLE
Fix beta APK build: use eas build --local

### DIFF
--- a/.github/workflows/build-beta-apk.yml
+++ b/.github/workflows/build-beta-apk.yml
@@ -39,21 +39,18 @@ jobs:
         working-directory: ./NaturalWineDetector
         run: npm ci
 
-      - name: Run Expo prebuild
+      - name: Install EAS CLI
+        run: npm install -g eas-cli@latest
+
+      - name: Build APK locally with EAS
         working-directory: ./NaturalWineDetector
-        run: npx expo prebuild --platform android --clean
+        run: eas build --platform android --profile preview --local --non-interactive --output ./build/NaturalWineDetector.apk
+        env:
+          EAS_NO_VCS: 1
 
-      - name: Build APK with Gradle
-        working-directory: ./NaturalWineDetector/android
-        run: ./gradlew assembleRelease --no-daemon
-
-      - name: Find and rename APK
-        id: apk
+      - name: Rename APK
         run: |
-          APK_PATH=$(find NaturalWineDetector/android -name "*.apk" -path "*/release/*" | head -1)
-          echo "Found APK at: $APK_PATH"
-          cp "$APK_PATH" NaturalWineDetector/NaturalWineDetector-${{ github.event.inputs.release_tag }}.apk
-          echo "apk_path=NaturalWineDetector/NaturalWineDetector-${{ github.event.inputs.release_tag }}.apk" >> $GITHUB_OUTPUT
+          mv NaturalWineDetector/build/NaturalWineDetector.apk NaturalWineDetector/build/NaturalWineDetector-${{ github.event.inputs.release_tag }}.apk
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -70,4 +67,4 @@ jobs:
             2. On your Android device, allow installation from unknown sources
             3. Open the APK file to install
           prerelease: true
-          files: ${{ steps.apk.outputs.apk_path }}
+          files: NaturalWineDetector/build/NaturalWineDetector-${{ github.event.inputs.release_tag }}.apk


### PR DESCRIPTION
The direct expo prebuild + Gradle approach fails with Expo SDK 52 module plugin resolution. Switch to eas build --local which handles the full native build pipeline correctly.