### PR TITLE
fix: use expo prebuild + Gradle for APK build (no EXPO_TOKEN needed)

### DIFF
--- a/.github/workflows/build-beta-apk.yml
+++ b/.github/workflows/build-beta-apk.yml
@@ -39,18 +39,34 @@ jobs:
         working-directory: ./NaturalWineDetector
         run: npm ci
 
-      - name: Install EAS CLI
-        run: npm install -g eas-cli@latest
-
-      - name: Build APK locally with EAS
+      - name: Generate Android project
         working-directory: ./NaturalWineDetector
-        run: eas build --platform android --profile preview --local --non-interactive --output ./build/NaturalWineDetector.apk
-        env:
-          EAS_NO_VCS: 1
+        run: npx expo prebuild --platform android --clean --no-install
 
-      - name: Rename APK
+      - name: Create JS bundle
+        working-directory: ./NaturalWineDetector
         run: |
-          mv NaturalWineDetector/build/NaturalWineDetector.apk NaturalWineDetector/build/NaturalWineDetector-${{ github.event.inputs.release_tag }}.apk
+          mkdir -p android/app/src/main/assets
+          npx react-native bundle \
+            --platform android \
+            --dev false \
+            --entry-file index.ts \
+            --bundle-output android/app/src/main/assets/index.android.bundle \
+            --assets-dest android/app/src/main/res
+
+      - name: Build APK with Gradle
+        working-directory: ./NaturalWineDetector/android
+        run: |
+          # Ensure node is available to Gradle for Expo modules resolution
+          export NODE_BINARY=$(which node)
+          ./gradlew assembleRelease --no-daemon -PreactNativeArchitectures=arm64-v8a
+
+      - name: Find and rename APK
+        run: |
+          APK_PATH=$(find NaturalWineDetector/android -name "*.apk" -path "*/release/*" | head -1)
+          echo "Found APK at: $APK_PATH"
+          mkdir -p NaturalWineDetector/build
+          cp "$APK_PATH" "NaturalWineDetector/build/NaturalWineDetector-${{ github.event.inputs.release_tag }}.apk"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
Replaces eas build --local approach (which requires EXPO_TOKEN) with:
- expo prebuild to generate native android project
- react-native bundle to create JS bundle manually
- Gradle assembleRelease for the final APK

This avoids Expo account authentication entirely.