### PR TITLE
fix: downgrade SDK 53 packages to SDK 52 compatible versions

### DIFF
--- a/NaturalWineDetector/package-lock.json
+++ b/NaturalWineDetector/package-lock.json
@@ -14,11 +14,10 @@
         "@react-navigation/stack": "^6.4.1",
         "axios": "^1.12.2",
         "expo": "~52.0.0",
-        "expo-asset": "^12.0.9",
         "expo-camera": "~16.0.0",
         "expo-crypto": "~14.0.0",
         "expo-file-system": "~18.0.0",
-        "expo-image-manipulator": "^14.0.7",
+        "expo-image-manipulator": "~13.0.0",
         "expo-image-picker": "~16.0.0",
         "expo-location": "~18.0.0",
         "expo-secure-store": "~14.0.0",
@@ -2817,19 +2816,6 @@
         "ms": "^2.1.1"
       }
     },
-    "node_modules/@expo/env": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@expo/env/-/env-2.0.7.tgz",
-      "integrity": "sha512-BNETbLEohk3HQ2LxwwezpG8pq+h7Fs7/vAMP3eAtFT1BCpprLYoBBFZH7gW4aqGfqOcVP4Lc91j014verrYNGg==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "debug": "^4.3.4",
-        "dotenv": "~16.4.5",
-        "dotenv-expand": "~11.0.6",
-        "getenv": "^2.0.0"
-      }
-    },
     "node_modules/@expo/fingerprint": {
       "version": "0.11.11",
       "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.11.11.tgz",
@@ -2904,24 +2890,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@expo/image-utils": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.8.7.tgz",
-      "integrity": "sha512-SXOww4Wq3RVXLyOaXiCCuQFguCDh8mmaHBv54h/R29wGl4jRY8GEyQEx8SypV/iHt1FbzsU/X3Qbcd9afm2W2w==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/spawn-async": "^1.7.2",
-        "chalk": "^4.0.0",
-        "getenv": "^2.0.0",
-        "jimp-compact": "0.16.1",
-        "parse-png": "^2.1.0",
-        "resolve-from": "^5.0.0",
-        "resolve-global": "^1.0.0",
-        "semver": "^7.6.0",
-        "temp-dir": "~2.0.0",
-        "unique-string": "~2.0.0"
       }
     },
     "node_modules/@expo/json-file": {
@@ -8458,21 +8426,6 @@
         }
       }
     },
-    "node_modules/expo-asset": {
-      "version": "12.0.9",
-      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-12.0.9.tgz",
-      "integrity": "sha512-vrdRoyhGhBmd0nJcssTSk1Ypx3Mbn/eXaaBCQVkL0MJ8IOZpAObAjfD5CTy8+8RofcHEQdh3wwZVCs7crvfOeg==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/image-utils": "^0.8.7",
-        "expo-constants": "~18.0.9"
-      },
-      "peerDependencies": {
-        "expo": "*",
-        "react": "*",
-        "react-native": "*"
-      }
-    },
     "node_modules/expo-camera": {
       "version": "16.0.18",
       "resolved": "https://registry.npmjs.org/expo-camera/-/expo-camera-16.0.18.tgz",
@@ -8491,108 +8444,6 @@
         "react-native-web": {
           "optional": true
         }
-      }
-    },
-    "node_modules/expo-constants": {
-      "version": "18.0.9",
-      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.9.tgz",
-      "integrity": "sha512-sqoXHAOGDcr+M9NlXzj1tGoZyd3zxYDy215W6E0Z0n8fgBaqce9FAYQE2bu5X4G629AYig5go7U6sQz7Pjcm8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/config": "~12.0.9",
-        "@expo/env": "~2.0.7"
-      },
-      "peerDependencies": {
-        "expo": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/expo-constants/node_modules/@expo/config": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-12.0.10.tgz",
-      "integrity": "sha512-lJMof5Nqakq1DxGYlghYB/ogSBjmv4Fxn1ovyDmcjlRsQdFCXgu06gEUogkhPtc9wBt9WlTTfqENln5HHyLW6w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "~7.10.4",
-        "@expo/config-plugins": "~54.0.2",
-        "@expo/config-types": "^54.0.8",
-        "@expo/json-file": "^10.0.7",
-        "deepmerge": "^4.3.1",
-        "getenv": "^2.0.0",
-        "glob": "^10.4.2",
-        "require-from-string": "^2.0.2",
-        "resolve-from": "^5.0.0",
-        "resolve-workspace-root": "^2.0.0",
-        "semver": "^7.6.0",
-        "slugify": "^1.3.4",
-        "sucrase": "3.35.0"
-      }
-    },
-    "node_modules/expo-constants/node_modules/@expo/config-plugins": {
-      "version": "54.0.2",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-54.0.2.tgz",
-      "integrity": "sha512-jD4qxFcURQUVsUFGMcbo63a/AnviK8WUGard+yrdQE3ZrB/aurn68SlApjirQQLEizhjI5Ar2ufqflOBlNpyPg==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/config-types": "^54.0.8",
-        "@expo/json-file": "~10.0.7",
-        "@expo/plist": "^0.4.7",
-        "@expo/sdk-runtime-versions": "^1.0.0",
-        "chalk": "^4.1.2",
-        "debug": "^4.3.5",
-        "getenv": "^2.0.0",
-        "glob": "^10.4.2",
-        "resolve-from": "^5.0.0",
-        "semver": "^7.5.4",
-        "slash": "^3.0.0",
-        "slugify": "^1.6.6",
-        "xcode": "^3.0.1",
-        "xml2js": "0.6.0"
-      }
-    },
-    "node_modules/expo-constants/node_modules/@expo/config-types": {
-      "version": "54.0.8",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-54.0.8.tgz",
-      "integrity": "sha512-lyIn/x/Yz0SgHL7IGWtgTLg6TJWC9vL7489++0hzCHZ4iGjVcfZmPTUfiragZ3HycFFj899qN0jlhl49IHa94A==",
-      "license": "MIT"
-    },
-    "node_modules/expo-constants/node_modules/@expo/json-file": {
-      "version": "10.0.7",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.7.tgz",
-      "integrity": "sha512-z2OTC0XNO6riZu98EjdNHC05l51ySeTto6GP7oSQrCvQgG9ARBwD1YvMQaVZ9wU7p/4LzSf1O7tckL3B45fPpw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "~7.10.4",
-        "json5": "^2.2.3"
-      }
-    },
-    "node_modules/expo-constants/node_modules/@expo/plist": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.7.tgz",
-      "integrity": "sha512-dGxqHPvCZKeRKDU1sJZMmuyVtcASuSYh1LPFVaM1DuffqPL36n6FMEL0iUqq2Tx3xhWk8wCnWl34IKplUjJDdA==",
-      "license": "MIT",
-      "dependencies": {
-        "@xmldom/xmldom": "^0.8.8",
-        "base64-js": "^1.2.3",
-        "xmlbuilder": "^15.1.1"
-      }
-    },
-    "node_modules/expo-constants/node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/expo-constants/node_modules/xmlbuilder": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
-      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0"
       }
     },
     "node_modules/expo-crypto": {
@@ -8630,22 +8481,13 @@
       }
     },
     "node_modules/expo-image-manipulator": {
-      "version": "14.0.7",
-      "resolved": "https://registry.npmjs.org/expo-image-manipulator/-/expo-image-manipulator-14.0.7.tgz",
-      "integrity": "sha512-NMHssudagLTAT6ZQ2upnJYT+gVLAt5vC+iD+TBIdV3ZS44yhrq+p2gCrYahDvtVywfmTI5WsbH+Sh1BXbmJUQw==",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/expo-image-manipulator/-/expo-image-manipulator-13.0.6.tgz",
+      "integrity": "sha512-Rz8Kcfx1xYm0AsIDi6zfKYUDnwCP8edgYXWb00KAkzOF8bDxwzTrnvESWhCiveM4IB3fojjLpNeENME34p3bzA==",
       "license": "MIT",
       "dependencies": {
-        "expo-image-loader": "~6.0.0"
+        "expo-image-loader": "~5.0.0"
       },
-      "peerDependencies": {
-        "expo": "*"
-      }
-    },
-    "node_modules/expo-image-manipulator/node_modules/expo-image-loader": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-6.0.0.tgz",
-      "integrity": "sha512-nKs/xnOGw6ACb4g26xceBD57FKLFkSwEUTDXEDF3Gtcu3MqF3ZIYd3YM+sSb1/z9AKV1dYT7rMSGVNgsveXLIQ==",
-      "license": "MIT",
       "peerDependencies": {
         "expo": "*"
       }
@@ -9490,15 +9332,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/getenv": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/getenv/-/getenv-2.0.0.tgz",
-      "integrity": "sha512-VilgtJj/ALgGY77fiLam5iD336eSWi96Q15JSAG1zi8NRBysm3LXKdGnHb4m5cuyxvOLQQKWpBZAT6ni4FI2iQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/glob": {
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
@@ -9562,18 +9395,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/global-dirs": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
-      "integrity": "sha512-NknMLn7F2J7aflwFOlGdNIuCDpN3VGoSoB+aap3KABFWbHVn1TCgFC+np23J8W2BiZbjfEw3BFBycSMv1AFblg==",
-      "license": "MIT",
-      "dependencies": {
-        "ini": "^1.3.4"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/globals": {
@@ -14736,18 +14557,6 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/resolve-global": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-global/-/resolve-global-1.0.0.tgz",
-      "integrity": "sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==",
-      "license": "MIT",
-      "dependencies": {
-        "global-dirs": "^0.1.1"
-      },
       "engines": {
         "node": ">=8"
       }

--- a/NaturalWineDetector/package.json
+++ b/NaturalWineDetector/package.json
@@ -4,8 +4,8 @@
   "main": "index.ts",
   "scripts": {
     "start": "expo start",
-    "android": "expo start --android",
-    "ios": "expo start --ios",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
     "web": "expo start --web",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
@@ -16,18 +16,16 @@
     "test:coverage": "jest --coverage"
   },
   "dependencies": {
-
     "@react-native-async-storage/async-storage": "^2.1.0",
     "@react-native-community/netinfo": "^11.3.1",
     "@react-navigation/native": "^6.1.18",
     "@react-navigation/stack": "^6.4.1",
     "axios": "^1.12.2",
     "expo": "~52.0.0",
-    "expo-asset": "^12.0.9",
     "expo-camera": "~16.0.0",
     "expo-crypto": "~14.0.0",
     "expo-file-system": "~18.0.0",
-    "expo-image-manipulator": "^14.0.7",
+    "expo-image-manipulator": "~13.0.0",
     "expo-image-picker": "~16.0.0",
     "expo-location": "~18.0.0",
     "expo-secure-store": "~14.0.0",


### PR DESCRIPTION
Root cause of all Android build failures: expo-asset@12.0.9, expo-constants@18.0.9, and expo-image-manipulator@14.0.7 are Expo SDK 53 packages that use expo-module-gradle-plugin, which doesn't exist in SDK 52.

Fix:
- Remove expo-asset as direct dependency (expo provides the correct v11.0.5)
- Downgrade expo-image-manipulator from ^14.0.7 to ~13.0.0
- expo-constants no longer hoisted (expo provides correct v17.0.8)