### PR TITLE
fix: pin Kotlin to 1.9.25 for Compose compiler compatibility

### DIFF
--- a/NaturalWineDetector/app.json
+++ b/NaturalWineDetector/app.json
@@ -51,6 +51,7 @@
       "bundler": "metro"
     },
     "plugins": [
+      "./plugins/withKotlinVersion",
       [
         "expo-camera",
         {

--- a/NaturalWineDetector/plugins/withKotlinVersion.js
+++ b/NaturalWineDetector/plugins/withKotlinVersion.js
@@ -1,0 +1,19 @@
+/**
+ * Config plugin to pin Kotlin Gradle plugin to 1.9.25.
+ *
+ * React Native 0.76.1's version catalog sets kotlin = "1.9.24",
+ * but expo-modules-core's Compose compiler 1.5.15 requires >= 1.9.25.
+ * This plugin adds an explicit version to the classpath dependency
+ * so Gradle resolves the correct Kotlin version.
+ */
+const { withProjectBuildGradle } = require('expo/config-plugins');
+
+module.exports = function withKotlinVersion(config) {
+  return withProjectBuildGradle(config, (config) => {
+    config.modResults.contents = config.modResults.contents.replace(
+      "classpath('org.jetbrains.kotlin:kotlin-gradle-plugin')",
+      "classpath('org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.25')"
+    );
+    return config;
+  });
+};


### PR DESCRIPTION
Add config plugin to pin kotlin-gradle-plugin to 1.9.25. RN 0.76.1's version catalog sets kotlin=1.9.24 but expo-modules-core's Compose compiler 1.5.15 requires >=1.9.25.