### PR TITLE
Fix: Status bar overlap and camera not working (#62)

### DIFF
--- a/NaturalWineDetector/src/components/CameraComponent.tsx
+++ b/NaturalWineDetector/src/components/CameraComponent.tsx
@@ -87,7 +87,7 @@ const CameraInterface: React.FC<CameraComponentProps> = ({
 
       // Launch camera
       const result = await ImagePicker.launchCameraAsync({
-        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        mediaTypes: ['images'],
         allowsEditing: true,
         aspect: [3, 4], // Good aspect ratio for wine bottles
         quality: 0.8, // Balance between quality and file size
@@ -142,7 +142,7 @@ const CameraInterface: React.FC<CameraComponentProps> = ({
     try {
       // Launch image picker
       const result = await ImagePicker.launchImageLibraryAsync({
-        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        mediaTypes: ['images'],
         allowsEditing: true,
         aspect: [3, 4],
         quality: 0.8,

--- a/NaturalWineDetector/src/components/OfflineIndicator.tsx
+++ b/NaturalWineDetector/src/components/OfflineIndicator.tsx
@@ -4,6 +4,7 @@
 
 import React from 'react';
 import { View, Text, StyleSheet, Animated } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNetworkState } from '../hooks/useNetworkState';
 
 interface OfflineIndicatorProps {
@@ -16,6 +17,7 @@ export const OfflineIndicator: React.FC<OfflineIndicatorProps> = ({
   position = 'top'
 }) => {
   const { isOffline } = useNetworkState();
+  const insets = useSafeAreaInsets();
   const [slideAnim] = React.useState(new Animated.Value(isOffline ? 0 : -50));
   const [wasOffline, setWasOffline] = React.useState(isOffline);
 
@@ -81,6 +83,8 @@ export const OfflineIndicator: React.FC<OfflineIndicatorProps> = ({
   const containerStyle = [
     styles.container,
     position === 'bottom' ? styles.bottom : styles.top,
+    position === 'top' && { paddingTop: insets.top },
+    position === 'bottom' && { paddingBottom: insets.bottom },
     { backgroundColor: getStatusColor() }
   ];
 
@@ -127,7 +131,6 @@ const styles = StyleSheet.create({
   },
   top: {
     top: 0,
-    paddingTop: 50, // Account for status bar
   },
   bottom: {
     bottom: 0,

--- a/NaturalWineDetector/src/components/WorkflowStatus.tsx
+++ b/NaturalWineDetector/src/components/WorkflowStatus.tsx
@@ -4,6 +4,7 @@ import {
   Text,
   StyleSheet,
 } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useWorkflow } from './WorkflowManager';
 
 interface WorkflowStatusProps {
@@ -16,6 +17,7 @@ export const WorkflowStatus: React.FC<WorkflowStatusProps> = ({
   position = 'top',
 }) => {
   const { state } = useWorkflow();
+  const insets = useSafeAreaInsets();
 
   if (!showProgress) {
     return null;
@@ -44,7 +46,9 @@ export const WorkflowStatus: React.FC<WorkflowStatusProps> = ({
   return (
     <View style={[
       styles.container,
-      position === 'bottom' && styles.containerBottom
+      position === 'top' && { paddingTop: insets.top },
+      position === 'bottom' && styles.containerBottom,
+      position === 'bottom' && { paddingBottom: insets.bottom },
     ]}>
       <View style={styles.content}>
         <View style={styles.stepInfo}>


### PR DESCRIPTION
## Summary

Fixes #62 — Screen content overlapping the system status bar on Android, and camera functionality issues.

## Changes

### 1. Fix status bar overlap (`WorkflowStatus.tsx`)
- Added `useSafeAreaInsets()` from `react-native-safe-area-context`
- Applied `paddingTop: insets.top` when the component is positioned at the top
- The workflow progress bar now renders **below** the system status bar instead of behind it

### 2. Fix status bar overlap (`OfflineIndicator.tsx`)
- Replaced hardcoded `paddingTop: 50` with dynamic `useSafeAreaInsets().top`
- Works correctly across all Android devices regardless of status bar height

### 3. Fix camera (`CameraComponent.tsx`)
- Replaced deprecated `ImagePicker.MediaTypeOptions.Images` with `['images']`
- This is the current API for expo-image-picker v16 (SDK 52) — the old `MediaTypeOptions` enum is deprecated and may cause runtime issues on some devices
- Applied the same fix to both `launchCameraAsync` and `launchImageLibraryAsync`

## Testing

- [ ] Verify the workflow status bar renders below the system status bar on Android
- [ ] Verify camera capture works on a physical Android device
- [ ] Verify gallery selection works
- [ ] Verify the offline indicator respects safe area insets
